### PR TITLE
fix: forgot that 914 upgrades are handled in two different files

### DIFF
--- a/SillySCP/Handlers/Server.cs
+++ b/SillySCP/Handlers/Server.cs
@@ -79,7 +79,7 @@ namespace SillySCP.Handlers
         {
             if (ev.KnobSetting == Scp914KnobSetting.Fine && ev.Pickup.Type == ItemType.Coin)
             {
-                int randomNum = UnityEngine.Random.Range(1, 3);
+                int randomNum = UnityEngine.Random.Range(1, 4);
                 switch (randomNum)
                 {
                     case 1:


### PR DESCRIPTION
I should've double checked to see if that was the only place that handled upgrading stuff in 914